### PR TITLE
ip and port configuration with environment vars

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -60,6 +60,13 @@ if [ "$1" = 'ts3server' ]; then
 		logquerycommands=${TS3SERVER_LOG_QUERY_COMMANDS:-0}
 		logappend=${TS3SERVER_LOG_APPEND:-0}
 		serverquerydocs_path=${TS3SERVER_SERVERQUERYDOCS_PATH:-/opt/ts3server/serverquerydocs/}
+		filetransfer_port=${TS3SERVER_LICENSEPATH}
+		query_ip=${TS3SERVER_QUERY_IP:0.0.0.0}
+		query_port=${TS3SERVER_QUERY_PORT:10011}
+		filetransfer_ip=${TS3SERVER_FILETRANSFER_IP:0.0.0.0}
+		filetransfer_port=${TS3SERVER_FILETRANSFER_PORT:30033}
+		voice_ip=${TS3SERVER_VOICE_IP:0.0.0.0}
+		default_voice_port=${TS3SERVER_DEFAULT_VOICE_PORT:9987}
 	EOF
 	cat <<- EOF >/var/run/ts3server/ts3db.ini
 		[config]

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -60,13 +60,12 @@ if [ "$1" = 'ts3server' ]; then
 		logquerycommands=${TS3SERVER_LOG_QUERY_COMMANDS:-0}
 		logappend=${TS3SERVER_LOG_APPEND:-0}
 		serverquerydocs_path=${TS3SERVER_SERVERQUERYDOCS_PATH:-/opt/ts3server/serverquerydocs/}
-		filetransfer_port=${TS3SERVER_LICENSEPATH}
-		query_ip=${TS3SERVER_QUERY_IP:0.0.0.0}
-		query_port=${TS3SERVER_QUERY_PORT:10011}
-		filetransfer_ip=${TS3SERVER_FILETRANSFER_IP:0.0.0.0}
-		filetransfer_port=${TS3SERVER_FILETRANSFER_PORT:30033}
-		voice_ip=${TS3SERVER_VOICE_IP:0.0.0.0}
-		default_voice_port=${TS3SERVER_DEFAULT_VOICE_PORT:9987}
+		query_ip=${TS3SERVER_QUERY_IP:-0.0.0.0}
+		query_port=${TS3SERVER_QUERY_PORT:-10011}
+		filetransfer_ip=${TS3SERVER_FILETRANSFER_IP:-0.0.0.0}
+		filetransfer_port=${TS3SERVER_FILETRANSFER_PORT:-30033}
+		voice_ip=${TS3SERVER_VOICE_IP:-0.0.0.0}
+		default_voice_port=${TS3SERVER_DEFAULT_VOICE_PORT:-9987}
 	EOF
 	cat <<- EOF >/var/run/ts3server/ts3db.ini
 		[config]


### PR DESCRIPTION
Allow to change the following ts3server.ini properties with environment variables:
query_ip: Default: 0.0.0.0 | Environment Variable: TS3SERVER_QUERY_IP
query_port: Default: 10011 | Environment Variable: TS3SERVER_QUERY_PORT

filetransfer_ip: Default: 0.0.0.0 | Environment Variable: TS3SERVER_FILETRANSFER_IP
filetransfer_port: Default: 30033 | Environment Variable: TS3SERVER_FILETRANSFER_PORT

voice_ip: Default: 0.0.0.0 | Environment Variable: TS3SERVER_VOICE_IP
default_voice_port: Default: 9987 | Environment Variable: TS3SERVER_DEFAULT_VOICE_PORT