### PR TITLE
Added support for custom entrypoint scripts

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,6 +18,7 @@ RUN set -eux; \
  wget "${TEAMSPEAK_URL}" -O server.tar.bz2; \
  echo "${TEAMSPEAK_CHECKSUM} *server.tar.bz2" | sha256sum -c -; \
  mkdir -p /opt/ts3server; \
+ mkdir /docker-entrypoint.d; \
  tar -xf server.tar.bz2 --strip-components=1 -C /opt/ts3server; \
  rm server.tar.bz2; \
  apk del .fetch-deps; \
@@ -32,8 +33,8 @@ WORKDIR /var/ts3server/
 #  9987 default voice
 # 10011 server query
 # 30033 file transport
-EXPOSE 9987/udp 10011 30033 
+EXPOSE 9987/udp 10011 30033
 
-COPY entrypoint.sh /opt/ts3server
+COPY --chown=ts3server:ts3server entrypoint.sh /opt/ts3server
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD [ "ts3server" ]

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'ts3server' ]; then
 	file_env 'TS3SERVER_DB_USER'
 	file_env 'TS3SERVER_DB_PASSWORD'
 	file_env 'TS3SERVER_DB_NAME'
-	
+
 	cat <<- EOF >/var/run/ts3server/ts3server.ini
 		licensepath=${TS3SERVER_LICENSEPATH}
 		query_protocols=${TS3SERVER_QUERY_PROTOCOLS:-raw}
@@ -72,5 +72,17 @@ if [ "$1" = 'ts3server' ]; then
 		wait_until_ready='${TS3SERVER_DB_WAITUNTILREADY:-30}'
 	EOF
 fi
+
+echo ""
+echo "*************************************************************************"
+echo "run entrypoint scripts"
+echo "*************************************************************************"
+echo ""
+for f in /docker-entrypoint.d/*; do
+    case "$f" in
+        *.sh) echo "$f"; /bin/sh "$f" ;;
+        *) ;;
+    esac
+done
 
 exec "$@"


### PR DESCRIPTION
### Description
With this PR you're able to mount custom entrypoint scripts into the container which are being executed *after* the teamspeak setup *before* the teamspeak server is started.

This resolves #22 