### PR TITLE
Explicitly set permission on entrypoint.sh

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,5 +35,6 @@ WORKDIR /var/ts3server/
 EXPOSE 9987/udp 10011 30033 
 
 COPY entrypoint.sh /opt/ts3server
+RUN chmod 755 /opt/ts3server/entrypoint.sh
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD [ "ts3server" ]


### PR DESCRIPTION
Resulting image would not start without if, for example, you're building using a build pipeline.
In my case I'm building with gitlab using kaniko. The proposed change does fix the issue.
