### PR TITLE
Fixed typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1135,7 +1135,7 @@ TeamSpeak.com
     data security and thus in particular for the protection of your personal
     data against dangers with the data transmission and the gaining of
     knowledge by third parties. These measures are adjusted regularly by
-    TeamSpeak to the state-of-the-at technology.
+    TeamSpeak to the state-of-the-art technology.
     17.2 TeamSpeak will provide you information at all times regarding the data
     security in the company. Please send your enquiry to privacy@teamspeak.com
     or to the data referred to in the imprint of the TeamSpeak Websites.


### PR DESCRIPTION
As #42 suggested, here's that fix.