### PR TITLE
Bump to alpine:3.14

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN apk add --no-cache ca-certificates libstdc++ su-exec libpq
 RUN set -eux; \


### PR DESCRIPTION
Building with the current alpine version 3.14 seems to to be no problem for the teamspeak3 image. So i think its a good idea to upgrade.