### PR TITLE
Support to use Custom GeoIP DB

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-RUN apk add --no-cache ca-certificates libstdc++ su-exec libpq
+RUN apk add --no-cache ca-certificates libstdc++ su-exec libpq libmaxminddb-dev
 RUN set -eux; \
     addgroup -g 9987 ts3server; \
     adduser -u 9987 -Hh /var/ts3server -G ts3server -s /sbin/nologin -D ts3server; \

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'ts3server' ]; then
         ${TS3SERVER_MACHINE_ID:+machine_id=${TS3SERVER_MACHINE_ID}}
         ${TS3SERVER_QUERY_SKIPBRUTEFORCECHECK:+query_skipbruteforcecheck=${TS3SERVER_QUERY_SKIPBRUTEFORCECHECk}}
         ${TS3SERVER_HINTS_ENABLED:+hints_enabled=${TS3SERVER_HINTS_ENABLED}}
+        ${TS3SERVER_MMDBPATH:+mmdbpath=${TS3SERVER_MMDBPATH}}
 EOF
 
     cat << EOF | sed 's/^[ \t]*//;s/[ \t]*$//;/^$/d' > /var/run/ts3server/ts3db.ini


### PR DESCRIPTION
Add libmaxminddb-dev to Baseimage and ENV-var: TS3SERVER_MMDBPATH to Support Custom GeoIP Database File. 
Funktion was added to Teamspeak Server in Version 3.13.0