### PR TITLE
Create docker-compose.yml with non root user

### DIFF
--- a/alpine/docker-compose.yml
+++ b/alpine/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+services:
+  teamspeak:
+    image: teamspeak:latest
+    restart: always
+    ports:
+      - 9987:9987/udp
+      - 10011:10011
+      - 30033:30033
+    environment:
+      TS3SERVER_LICENSE: accept
+    volumes:
+      - ./data:/var/ts3server
+    user: "9987:9987"  # Run the container as the ts3server user


### PR DESCRIPTION
Run user as 9987 (ts3server), because official documentation doesn't say that. It's better to run as non root user. 

Make sure to change ownership of data folder on the host to 9987.